### PR TITLE
Use interface in extensions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nvika": {
+      "version": "2.2.0",
+      "commands": [
+        "nvika"
+      ]
+    },
+    "jetbrains.resharper.globaltools": {
+      "version": "2021.2.2",
+      "commands": [
+        "jb"
+      ]
+    }
+  }
+}

--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -1,27 +1,31 @@
 name: Code Quality
-
-on:
-  pull_request:
-    branches:
-      - master
+on: [ pull_request, push ]
 
 jobs:
   quality:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
-      - name: Download CodeCutter
-        run: powershell Invoke-WebRequest -Uri "https://github.com/dragonfruitnetwork/CodeCutter/releases/latest/download/DragonFruit.CodeCutter.exe" -OutFile ".\DragonFruit.CodeCutter.exe"
-          
-      - name: "Setup MSBuild"
-        uses: microsoft/setup-msbuild@v1.0.2
-                            
-      - name: NuGet Restore
-        run: |
-          nuget locals all -clear
-          nuget restore
-      
-      - name: Code Quality Check
-        run: ".\\DragonFruit.CodeCutter.exe"
+
+      - name: Install .NET 3.1.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
+
+      - name: Install .NET 6.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Restore Tools
+        run: dotnet tool restore
+
+      - name: Restore Packages
+        run: dotnet restore
+
+      - name: InspectCode
+        run: dotnet jb inspectcode ${{github.workspace}}/DragonFruit.Link.sln --output=${{github.workspace}}/inspectcodereport.xml --cachesDir=${{github.workspace}}/inspectcode --verbosity=WARN --no-build
+
+      - name: NVika
+        run: dotnet nvika parsereport "${{github.workspace}}/inspectcodereport.xml"

--- a/DragonFruit.Link.Tests/DragonFruit.Link.Tests.csproj
+++ b/DragonFruit.Link.Tests/DragonFruit.Link.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DragonFruit.Link/DragonFruit.Link.csproj
+++ b/DragonFruit.Link/DragonFruit.Link.csproj
@@ -15,11 +15,11 @@
     <!--    todo use packaged icon-->
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/31821773</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DragonFruit.Common.Data" Version="2021.910.47" />
+    <PackageReference Include="DragonFruit.Common.Data" Version="2021.1130.58-beta" />
   </ItemGroup>
 
 </Project>

--- a/DragonFruit.Link/Economy/Extensions/SteamGameEconomyAssetInfoExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamGameEconomyAssetInfoExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Economy.Objects;
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
@@ -19,7 +20,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="items">An <see cref="IEnumerable{T}"/> of items to get info for</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The assets requested in the <see cref="items"/> argument</returns>
-        public static IEnumerable<SteamGameEconomyAsset> GetMarketItemsForApp(this SteamApiClient client, uint appId, IEnumerable<ulong> items, CancellationToken token = default)
+        public static IEnumerable<SteamGameEconomyAsset> GetMarketItemsForApp<T>(this T client, uint appId, IEnumerable<ulong> items, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameEconomyAssetInfoRequest(appId, items);
             return client.Perform<SteamGameEconomyAssetInfoResponse>(request, token)?.Assets;

--- a/DragonFruit.Link/Economy/Extensions/SteamGameEconomyAssetPriceExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamGameEconomyAssetPriceExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Economy.Objects;
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
@@ -18,7 +19,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="appId">The App Id to get market info for</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>A list of all the items and their prices in various currencies</returns>
-        public static IEnumerable<SteamGameEconomyAssetPriceInfo> GetMarketPricesForApp(this SteamApiClient client, uint appId, CancellationToken token = default)
+        public static IEnumerable<SteamGameEconomyAssetPriceInfo> GetMarketPricesForApp<T>(this T client, uint appId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameEconomyAssetPriceRequest(appId);
             return client.Perform<SteamGameEconomyAssetPriceResponse>(request, token)?.PriceInfo.Assets;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeCancelExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeCancelExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Exceptions;
 
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="offerId">The id of the offer to cancel</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
-        public static void CancelTrade(this SteamApiClient client, ulong offerId, CancellationToken token = default)
+        public static void CancelTrade<T>(this T client, ulong offerId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeCancelRequest(offerId);
             HttpResponseMessage result = null;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeDeclineExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeDeclineExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Exceptions;
 
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="offerId">The id of the offer to decline</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
-        public static void DeclineTrade(this SteamApiClient client, ulong offerId, CancellationToken token = default)
+        public static void DeclineTrade<T>(this T client, ulong offerId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeDeclineRequest(offerId);
             HttpResponseMessage result = null;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeHistoryExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeHistoryExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Economy.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="maxEntries">Max number of trades to return</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>Returns up-to the <see cref="maxEntries"/> of trades and descriptions of the items in referenced trades</returns>
-        public static SteamUserTradeHistoryContainer GetTradeHistory(this SteamApiClient client, uint maxEntries, CancellationToken token = default)
+        public static SteamUserTradeHistoryContainer GetTradeHistory<T>(this T client, uint maxEntries, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeHistoryRequest(maxEntries);
             return client.Perform<SteamUserTradeHistoryResponse>(request, token)?.History;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeHoldDurationExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeHoldDurationExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Economy.Extensions
 {
@@ -17,7 +18,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="targetToken">The `token` parameter of the user's Trade URL</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The info of all parties' hold durations and a final one that will be used in the real trade</returns>
-        public static SteamUserTradeHoldDurationContainer GetTradeHoldDurations(this SteamApiClient client, ulong targetUser, string targetToken, CancellationToken token = default)
+        public static SteamUserTradeHoldDurationContainer GetTradeHoldDurations<T>(this T client, ulong targetUser, string targetToken, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeHoldDurationRequest(targetUser, targetToken);
             return client.Perform<SteamUserTradeHoldDurationResponse>(request, token)?.HoldDurations;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeOfferExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeOfferExtensions.cs
@@ -5,6 +5,7 @@ using DragonFruit.Link.Economy.Objects;
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Economy.Extensions
 {
@@ -17,7 +18,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="tradeId">The id of the trade</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The offer information and descriptions, or null if the trade id is invalid/party has no involvement</returns>
-        public static SteamUserTradeOffer GetTradeOffer(this SteamApiClient client, ulong tradeId, CancellationToken token = default)
+        public static SteamUserTradeOffer GetTradeOffer<T>(this T client, ulong tradeId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeOfferRequest(tradeId);
             return client.Perform<SteamUserTradeOfferResponse>(request, token)?.OfferLookupResult?.Offer;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeOffersExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeOffersExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Economy.Extensions
 {
@@ -15,7 +16,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>A collection of sent and received offers, with their item descriptions</returns>
-        public static SteamUserTradeOffersContainer GetTrades(this SteamApiClient client, CancellationToken token = default)
+        public static SteamUserTradeOffersContainer GetTrades<T>(this T client, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeOffersRequest();
             return client.Perform<SteamUserTradeOffersResponse>(request, token)?.Offers;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeOffersSummaryExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeOffersSummaryExtensions.cs
@@ -5,6 +5,7 @@ using DragonFruit.Link.Economy.Objects;
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Economy.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>A summary of the user's trade offers</returns>
-        public static SteamUserTradeOffersSummary GetTradeOffersSummary(this SteamApiClient client, CancellationToken token = default)
+        public static SteamUserTradeOffersSummary GetTradeOffersSummary<T>(this T client, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeOffersSummaryRequest();
             return client.Perform<SteamUserTradeOffersSummaryResponse>(request, token)?.Summary;

--- a/DragonFruit.Link/Economy/Extensions/SteamUserTradeStatusExtensions.cs
+++ b/DragonFruit.Link/Economy/Extensions/SteamUserTradeStatusExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Economy.Requests;
 using DragonFruit.Link.Economy.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Economy.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Economy.Extensions
         /// <param name="tradeId">Id of trade to return</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>Returns the trade and descriptions of the items included in said trade</returns>
-        public static SteamUserTradeHistoryContainer GetTradeStatus(this SteamApiClient client, ulong tradeId, CancellationToken token = default)
+        public static SteamUserTradeHistoryContainer GetTradeStatus<T>(this T client, ulong tradeId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserTradeStatusRequest(tradeId);
             return client.Perform<SteamUserTradeStatusResponse>(request, token)?.History;

--- a/DragonFruit.Link/Game/Extensions/SteamGameSchemaExtensions.cs
+++ b/DragonFruit.Link/Game/Extensions/SteamGameSchemaExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Game.Requests;
 using DragonFruit.Link.Game.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Game.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Game.Extensions
         /// <param name="appId">The App Id to get the schema for</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns></returns>
-        public static SteamGameSchemaContainer GetSchemaForGame(this SteamApiClient client, uint appId, CancellationToken token = default)
+        public static SteamGameSchemaContainer GetSchemaForGame<T>(this T client, uint appId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameSchemaRequest(appId);
             return client.Perform<SteamGameSchemaResponse>(request, token)?.Schema;

--- a/DragonFruit.Link/ISteamApiClient.cs
+++ b/DragonFruit.Link/ISteamApiClient.cs
@@ -1,0 +1,13 @@
+﻿// DragonFruit Link API Copyright 2021 (C) DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under the GNU GPLv3 License. Refer to the license.md file at the root of the repo for more info
+
+namespace DragonFruit.Link
+{
+    /// <summary>
+    /// Abstraction of the properties required for authenticated <see cref="SteamApiRequest"/>s to work
+    /// </summary>
+    public interface ISteamApiClient
+    {
+        string ApiKey { get; }
+    }
+}

--- a/DragonFruit.Link/Library/Extensions/SteamSharedGameCheckExtensions.cs
+++ b/DragonFruit.Link/Library/Extensions/SteamSharedGameCheckExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Library.Requests;
 using DragonFruit.Link.Library.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Library.Extensions
 {
@@ -18,7 +19,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The Game Owners' SteamID64</returns>
         /// <remarks>The user must be currently playing the game for this to return a valid result. If 0 is returned the user either owns the game or they aren't currently playing it.</remarks>
-        public static ulong? GetSharedGameOwner(this SteamApiClient client, uint appId, ulong steamId, CancellationToken token = default)
+        public static ulong? GetSharedGameOwner<T>(this T client, uint appId, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamSharedGameCheckRequest(steamId, appId);
             return client.Perform<SteamSharedGameCheckResponse>(request, token)?.LenderInfo.LenderSteamId;

--- a/DragonFruit.Link/Library/Extensions/SteamStoreListingExtensions.cs
+++ b/DragonFruit.Link/Library/Extensions/SteamStoreListingExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Library.Requests;
 using DragonFruit.Link.Library.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Library.Extensions
 {
@@ -17,7 +18,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>10,000 Items being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreItems(this SteamApiClient client, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreItems<T>(this T client, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest();
             return client.Perform<SteamStoreListingResponse>(request, token).Listing;
@@ -29,7 +30,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="maxItems">Max number of entries to be returned</param>
         /// <returns>Up-to <see cref="maxItems"/> items being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreItems(this SteamApiClient client, uint maxItems, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreItems<T>(this T client, uint maxItems, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {
@@ -45,7 +46,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="lastItem">Container with the last app id inside (everything else can be empty)</param>
         /// <returns>The next 10,000 items being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreItems(this SteamApiClient client, SteamStoreListingContainer lastItem, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreItems<T>(this T client, SteamStoreListingContainer lastItem, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {
@@ -61,7 +62,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="maxItems">Max number of entries to be returned</param>
         /// <returns>Up-to <see cref="maxItems"/> items being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreItems(this SteamApiClient client, uint maxItems, SteamStoreListingContainer lastItem, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreItems<T>(this T client, uint maxItems, SteamStoreListingContainer lastItem, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {
@@ -82,7 +83,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>10,000 apps or games being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreApps(this SteamApiClient client, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreApps<T>(this T client, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {
@@ -103,7 +104,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="maxItems">Max number of entries to be returned</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>Up-to <see cref="maxItems"/> games and apps being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreApps(this SteamApiClient client, uint maxItems, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreApps<T>(this T client, uint maxItems, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {
@@ -126,7 +127,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="lastItem">Container with the last app id inside (everything else can be empty)</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The next 10,000 apps and games being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreApps(this SteamApiClient client, SteamStoreListingContainer lastItem, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreApps<T>(this T client, SteamStoreListingContainer lastItem, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {
@@ -149,7 +150,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="maxItems">Max number of entries to be returned</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>Up-to <see cref="maxItems"/> games and apps being sold on the Steam store</returns>
-        public static SteamStoreListingContainer GetStoreApps(this SteamApiClient client, uint maxItems, SteamStoreListingContainer lastItem, CancellationToken token = default)
+        public static SteamStoreListingContainer GetStoreApps<T>(this T client, uint maxItems, SteamStoreListingContainer lastItem, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamStoreListingRequest
             {

--- a/DragonFruit.Link/Library/Extensions/SteamUserLibraryExtensions.cs
+++ b/DragonFruit.Link/Library/Extensions/SteamUserLibraryExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Library.Objects;
 using DragonFruit.Link.Library.Requests;
 using DragonFruit.Link.Library.Responses;
@@ -12,24 +13,14 @@ namespace DragonFruit.Link.Library.Extensions
     public static class SteamUserLibraryExtensions
     {
         /// <summary>
-        /// List all the paid apps owned by the user
-        /// </summary>
-        /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
-        /// <param name="steamId">The user's SteamID64</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamApp"/>s, representing the games/apps owned by the user</returns>
-        public static IEnumerable<SteamApp> GetUserAppLibrary(this SteamApiClient client, ulong steamId)
-        {
-            return GetUserAppLibrary(client, steamId, false);
-        }
-
-        /// <summary>
         /// List all the apps owned by the user, optionally including free-to-play games
         /// </summary>
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="steamId">The user's SteamID64</param>
+        /// <param name="includeFreeGames">Whether to include free-to-play games (defaults to false)</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamApp"/>s, representing the games/apps owned by the user</returns>
-        public static IEnumerable<SteamApp> GetUserAppLibrary(this SteamApiClient client, ulong steamId, bool includeFreeGames, CancellationToken token = default)
+        public static IEnumerable<SteamApp> GetUserAppLibrary<T>(this T client, ulong steamId, bool includeFreeGames = false, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserLibraryRequest(steamId, includeFreeGames);
             return client.Perform<SteamUserLibraryResponse>(request, token)?.Library.Apps;

--- a/DragonFruit.Link/Library/Extensions/SteamUserRecentsExtensions.cs
+++ b/DragonFruit.Link/Library/Extensions/SteamUserRecentsExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Library.Objects;
 using DragonFruit.Link.Library.Requests;
 using DragonFruit.Link.Library.Responses;
@@ -18,7 +19,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="steamId">The user's SteamID64</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamApp"/>s, representing the games/apps recently used</returns>
-        public static IEnumerable<SteamApp> GetUserRecentApps(this SteamApiClient client, ulong steamId, CancellationToken token = default)
+        public static IEnumerable<SteamApp> GetUserRecentApps<T>(this T client, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserRecentsRequest(steamId);
             return client.Perform<SteamUserLibraryResponse>(request, token)?.Library.Apps;
@@ -32,7 +33,7 @@ namespace DragonFruit.Link.Library.Extensions
         /// <param name="maxEntries">The maximum number of items to return</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamApp"/>s, representing the games/apps recently used</returns>
-        public static IEnumerable<SteamApp> GetUserRecentApps(this SteamApiClient client, ulong steamId, ushort maxEntries, CancellationToken token = default)
+        public static IEnumerable<SteamApp> GetUserRecentApps<T>(this T client, ulong steamId, ushort maxEntries, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserRecentsRequest(steamId, maxEntries);
             return client.Perform<SteamUserLibraryResponse>(request, token)?.Library.Apps;

--- a/DragonFruit.Link/Servers/Extensions/SteamGameServerAccountCreationExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamGameServerAccountCreationExtensions.cs
@@ -5,6 +5,7 @@ using DragonFruit.Link.Servers.Objects;
 using DragonFruit.Link.Servers.Requests;
 using DragonFruit.Link.Servers.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Servers.Extensions
 {
@@ -18,7 +19,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="memo">The note attached to the server, for personal reference.</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The login info for the server</returns>
-        public static SteamGameServerAccountLoginInfo CreateGameServer(this SteamApiClient client, uint appId, string memo, CancellationToken token = default)
+        public static SteamGameServerAccountLoginInfo CreateGameServer<T>(this T client, uint appId, string memo, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameServerAccountCreationRequest(appId, memo);
             return client.Perform<SteamGameServerAccountCreationResponse>(request, token)?.AccountLoginInfo;

--- a/DragonFruit.Link/Servers/Extensions/SteamGameServerDeletionExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamGameServerDeletionExtensions.cs
@@ -3,6 +3,7 @@
 
 using DragonFruit.Link.Servers.Requests;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Servers.Extensions
 {
@@ -14,7 +15,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="serverId">The Steam Id of the game server</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
-        public static void DeleteGameServer(this SteamApiClient client, ulong serverId, CancellationToken token = default)
+        public static void DeleteGameServer<T>(this T client, ulong serverId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameServerDeletionRequest(serverId);
             var response = client.Perform(request, token);

--- a/DragonFruit.Link/Servers/Extensions/SteamGameServerLoginResetExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamGameServerLoginResetExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.Servers.Requests;
 using DragonFruit.Link.Servers.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Servers.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="serverId">The Steam Id of the game server</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The new login token</returns>
-        public static string ResetServerLoginToken(this SteamApiClient client, ulong serverId, CancellationToken token = default)
+        public static string ResetServerLoginToken<T>(this T client, ulong serverId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameServerLoginResetRequest(serverId);
             return client.Perform<SteamGameServerLoginResetResponse>(request, token)?.AccountInfo.ServerToken;

--- a/DragonFruit.Link/Servers/Extensions/SteamGameServerLoginTokenInfoExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamGameServerLoginTokenInfoExtensions.cs
@@ -5,6 +5,7 @@ using DragonFruit.Link.Servers.Objects;
 using DragonFruit.Link.Servers.Requests;
 using DragonFruit.Link.Servers.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Servers.Extensions
 {
@@ -17,7 +18,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="loginToken">The login token to query. The API key owner must have own the server for this to work</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>A condensed server account info response</returns>
-        public static SteamGameServerCondensedAccountInfo GetServerLoginTokenInfo(this SteamApiClient client, string loginToken, CancellationToken token = default)
+        public static SteamGameServerCondensedAccountInfo GetServerLoginTokenInfo<T>(this T client, string loginToken, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameServerLoginTokenInfoRequest(loginToken);
             return client.Perform<SteamGameServerLoginTokenInfoResponse>(request, token)?.CondensedAccountInfo;

--- a/DragonFruit.Link/Servers/Extensions/SteamGameServerMemoChangeExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamGameServerMemoChangeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Servers.Requests;
 
 namespace DragonFruit.Link.Servers.Extensions
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="serverId">The Steam Id of the game server</param>
         /// <param name="newMemo">The new memo to set</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
-        public static void ChangeServerMemo(this SteamApiClient client, ulong serverId, string newMemo, CancellationToken token = default)
+        public static void ChangeServerMemo<T>(this T client, ulong serverId, string newMemo, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             HttpResponseMessage response = null;
 

--- a/DragonFruit.Link/Servers/Extensions/SteamGameServerPublicInfoExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamGameServerPublicInfoExtensions.cs
@@ -5,6 +5,7 @@ using DragonFruit.Link.Servers.Objects;
 using DragonFruit.Link.Servers.Requests;
 using DragonFruit.Link.Servers.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Servers.Extensions
 {
@@ -17,7 +18,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="serverId">The Steam Id of the server to get the info for</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The server's public facing information</returns>
-        public static SteamGameServerPublicInfo GetServerInfo(this SteamApiClient client, ulong serverId, CancellationToken token = default)
+        public static SteamGameServerPublicInfo GetServerInfo<T>(this T client, ulong serverId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamGameServerPublicInfoRequest(serverId);
             return client.Perform<SteamGameServerPublicInfoResponse>(request, token)?.PublicInfo;

--- a/DragonFruit.Link/Servers/Extensions/SteamUserGameServerListingExtensions.cs
+++ b/DragonFruit.Link/Servers/Extensions/SteamUserGameServerListingExtensions.cs
@@ -5,6 +5,7 @@ using DragonFruit.Link.Servers.Objects;
 using DragonFruit.Link.Servers.Requests;
 using DragonFruit.Link.Servers.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.Servers.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.Servers.Extensions
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The API key owner's account standing and any server they have registered, for all games</returns>
-        public static SteamUserGameServerListing GetGameServers(this SteamApiClient client, CancellationToken token = default)
+        public static SteamUserGameServerListing GetGameServers<T>(this T client, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserGameServerListingRequest();
             return client.Perform<SteamUserGameServerListingResponse>(request, token)?.ServerListing;

--- a/DragonFruit.Link/SteamApiClient.cs
+++ b/DragonFruit.Link/SteamApiClient.cs
@@ -3,51 +3,19 @@
 
 using DragonFruit.Common.Data;
 using DragonFruit.Common.Data.Serializers;
-using DragonFruit.Link.Exceptions;
 
 namespace DragonFruit.Link
 {
-    public class SteamApiClient : ApiClient<ApiJsonSerializer>
+    public class SteamApiClient : ApiClient<ApiJsonSerializer>, ISteamApiClient
     {
-        private readonly string _apiKey;
-        private readonly bool _apiKeySet;
-
-        #region Constructors
-
-        public SteamApiClient(string apiKey)
+        public SteamApiClient(string api)
         {
-            _apiKey = apiKey;
-            _apiKeySet = true;
+            ApiKey = api;
         }
 
-        public SteamApiClient(string apiKey, string userAgent)
-            : this(apiKey)
-        {
-            UserAgent = userAgent;
-        }
-
-        #endregion
-
-        protected override void ValidateRequest(ApiRequest requestData)
-        {
-            base.ValidateRequest(requestData);
-
-            if (!(requestData is SteamApiRequest steamRequest))
-            {
-                return;
-            }
-
-            if (!steamRequest.RequireApiKey)
-            {
-                return;
-            }
-
-            if (!_apiKeySet)
-            {
-                throw new SteamApiKeyMissingException();
-            }
-
-            steamRequest.ApiKey = _apiKey;
-        }
+        /// <summary>
+        /// The api key to use in authenticated requests
+        /// </summary>
+        public string ApiKey { get; }
     }
 }

--- a/DragonFruit.Link/Store/SteamStoreApiRequest.cs
+++ b/DragonFruit.Link/Store/SteamStoreApiRequest.cs
@@ -21,7 +21,7 @@ namespace DragonFruit.Link.Store
 
         public abstract string RequestPath { get; }
 
-        public override string PathOverride => $"https://store.steampowered.com/api/{RequestPath}/";
+        public override string? PathOverride => $"https://store.steampowered.com/api/{RequestPath}/";
 
         [JsonProperty("l")]
         public string LanguageName { get; set; }

--- a/DragonFruit.Link/User/Extensions/SteamUserAchievementsExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserAchievementsExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.User.Objects;
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
@@ -19,7 +20,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamId">The user's SteamID64</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamUserAchievementObject"/>s</returns>
-        public static IEnumerable<SteamUserAchievementObject> GetUserAchievements(this SteamApiClient client, uint appId, ulong steamId, CancellationToken token = default)
+        public static IEnumerable<SteamUserAchievementObject> GetUserAchievements<T>(this T client, uint appId, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserAchievementsRequest(steamId, appId);
             return client.Perform<SteamUserAchievementsResponse>(request, token)?.Player.Achievements;

--- a/DragonFruit.Link/User/Extensions/SteamUserBadgesExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserBadgesExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.User.Extensions
 {
@@ -15,7 +16,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="client">The <see cref="SteamApiRequest"/> to use</param>
         /// <param name="steamId">The user's SteamID64</param>
         /// <returns>A <see cref="SteamUserBadgesInfo"/> item containing badges and level info</returns>
-        public static SteamUserBadgesInfo GetUserBadges(this SteamApiClient client, ulong steamId, CancellationToken token = default)
+        public static SteamUserBadgesInfo GetUserBadges<T>(this T client, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserBadgesRequest(steamId);
             return client.Perform<SteamUserBadgesResponse>(request, token)?.BadgeInfo;

--- a/DragonFruit.Link/User/Extensions/SteamUserFriendsExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserFriendsExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.User.Objects;
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
@@ -19,7 +20,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamUserFriend"/> objects</returns>
         /// <remarks>This will cause an exception if the user's friend list is set to something other than "Public"</remarks>
-        public static IEnumerable<SteamUserFriend> GetUserFriends(this SteamApiClient client, ulong steamId, CancellationToken token = default)
+        public static IEnumerable<SteamUserFriend> GetUserFriends<T>(this T client, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserFriendsRequest(steamId);
             return client.Perform<SteamUserFriendsResponse>(request, token)?.Container.Friends;

--- a/DragonFruit.Link/User/Extensions/SteamUserGameStatsExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserGameStatsExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.User.Extensions
 {
@@ -17,7 +18,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamId">The user's SteamID64</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>A <see cref="SteamUserGameStatsContainer"/>, containing stats and (sometimes) achievements</returns>
-        public static SteamUserGameStatsContainer GetUserGameStats(this SteamApiClient client, uint appId, ulong steamId, CancellationToken token = default)
+        public static SteamUserGameStatsContainer GetUserGameStats<T>(this T client, uint appId, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserGameStatsRequest(steamId, appId);
             return client.Perform<SteamUserGameStatsResponse>(request, token)?.Player;

--- a/DragonFruit.Link/User/Extensions/SteamUserLevelExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserLevelExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.User.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamId">The user's SteamID64</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An unsigned int32 representing the user's level</returns>
-        public static uint? GetUserLevel(this SteamApiClient client, ulong steamId, CancellationToken token = default)
+        public static uint? GetUserLevel<T>(this T client, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserLevelRequest(steamId);
             return client.Perform<SteamUserLevelResponse>(request, token)?.UserLevelInfo.Level;

--- a/DragonFruit.Link/User/Extensions/SteamUserLinkResolveExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserLinkResolveExtensions.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
 using System.Threading;
+using DragonFruit.Common.Data;
 
 namespace DragonFruit.Link.User.Extensions
 {
@@ -16,7 +17,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="linkSegment">The segment of the vanity url the user chooses (if the overall link is https://steamcommunity.com/id/papa_curry to get their id pass "papa_curry")</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The users SteamID64 (or null if the link was not found)</returns>
-        public static ulong? ResolveVanityUrl(this SteamApiClient client, string linkSegment, CancellationToken token = default)
+        public static ulong? ResolveVanityUrl<T>(this T client, string linkSegment, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserLinkResolveRequest(linkSegment);
             return client.Perform<SteamUserLinkResolveResponse>(request, token)?.LinkInfo?.Id;

--- a/DragonFruit.Link/User/Extensions/SteamUserProfileExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserProfileExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.Exceptions;
 using DragonFruit.Link.User.Objects;
 using DragonFruit.Link.User.Requests;
@@ -20,7 +21,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="client">The <see cref="SteamApiClient"/> to use</param>
         /// <param name="steamUrl">The user's steam link, with or without the domain</param>
         /// <returns>The user's <see cref="SteamUserProfile"/>, providing the url was valid</returns>
-        public static SteamUserProfile GetUserProfile(this SteamApiClient client, string steamUrl)
+        public static SteamUserProfile GetUserProfile<T>(this T client, string steamUrl) where T : ApiClient, ISteamApiClient
         {
             ulong? steamId = null;
 
@@ -49,8 +50,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamId">The user's SteamID64</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>The user's <see cref="SteamUserProfile"/></returns>
-        public static SteamUserProfile GetUserProfile(this SteamApiClient client, ulong steamId,
-                                                      CancellationToken token = default)
+        public static SteamUserProfile GetUserProfile<T>(this T client, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserProfileRequest(steamId);
             return client.Perform<SteamUserProfileResponse>(request, token)?.Container?.Profiles.Single();
@@ -63,9 +63,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamIds"><see cref="IEnumerable{T}"/> of user SteamID64s</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SteamUserProfile"/></returns>
-        public static IEnumerable<SteamUserProfile> GetUserProfile(this SteamApiClient client,
-                                                                   IEnumerable<ulong> steamIds,
-                                                                   CancellationToken token = default)
+        public static IEnumerable<SteamUserProfile> GetUserProfile<T>(this T client, IEnumerable<ulong> steamIds, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserProfileRequest(steamIds);
             return client.Perform<SteamUserProfileResponse>(request, token)?.Container?.Profiles;

--- a/DragonFruit.Link/User/Extensions/SteamUserRestrictionsExtensions.cs
+++ b/DragonFruit.Link/User/Extensions/SteamUserRestrictionsExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using DragonFruit.Common.Data;
 using DragonFruit.Link.User.Objects;
 using DragonFruit.Link.User.Requests;
 using DragonFruit.Link.User.Responses;
@@ -19,7 +20,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamId">The user's SteamID64</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>A <see cref="SteamUserRestriction"/> object containing the user's record</returns>
-        public static SteamUserRestriction GetUserRestrictions(this SteamApiClient client, ulong steamId, CancellationToken token = default)
+        public static SteamUserRestriction GetUserRestrictions<T>(this T client, ulong steamId, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserRestrictionsRequest(steamId);
             return client.Perform<SteamUserRestrictionsResponse>(request, token)?.Accounts.Single();
@@ -32,7 +33,7 @@ namespace DragonFruit.Link.User.Extensions
         /// <param name="steamIds"><see cref="IEnumerable{T}"/> of user SteamID64s</param>
         /// <param name="token">The <see cref="CancellationToken"/> to pass when performing the request</param>
         /// <returns>Multiple <see cref="SteamUserRestriction"/> object containing the user's record</returns>
-        public static IEnumerable<SteamUserRestriction> GetUserRestrictions(this SteamApiClient client, IEnumerable<ulong> steamIds, CancellationToken token = default)
+        public static IEnumerable<SteamUserRestriction> GetUserRestrictions<T>(this T client, IEnumerable<ulong> steamIds, CancellationToken token = default) where T : ApiClient, ISteamApiClient
         {
             var request = new SteamUserRestrictionsRequest(steamIds);
             return client.Perform<SteamUserRestrictionsResponse>(request, token)?.Accounts;

--- a/codecutter.json
+++ b/codecutter.json
@@ -1,1 +1,0 @@
-{"solution":"DragonFruit.Link.sln","displayLevel":3,"errorLevel":3}


### PR DESCRIPTION
depends on #60

this now allows all extensions to be used by any apiclient, and if an api key is required, then the `ISteamApiClient` interface will need to be implemented by the client